### PR TITLE
add support for mass payments

### DIFF
--- a/lib/dwolla/amount.ex
+++ b/lib/dwolla/amount.ex
@@ -1,0 +1,8 @@
+defmodule Dwolla.Amount do
+  @moduledoc """
+  Dwolla Amount data structure.
+  """
+
+  defstruct value: nil, currency: nil
+  @type t :: %__MODULE__{value: String.t(), currency: String.t()}
+end

--- a/lib/dwolla/mass_payment.ex
+++ b/lib/dwolla/mass_payment.ex
@@ -1,0 +1,134 @@
+defmodule Dwolla.MassPayment do
+  @moduledoc """
+  Functions for `mass-payments` endpoint.
+  """
+
+  alias Dwolla.Utils
+
+  defstruct id: nil,
+            created: nil,
+            status: nil,
+            metadata: nil,
+            funding_transfer_id: nil,
+            source_funding_source_id: nil,
+            correlation_id: nil,
+            total: nil,
+            total_fees: nil
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          created: String.t(),
+          # "deferred" | "pending" | "processing" | "complete" |
+          status: String.t(),
+          metadata: Map.t(),
+          funding_transfer_id: String.t(),
+          source_funding_source_id: String.t(),
+          correlation_id: String.t(),
+          total: Dwolla.Amount.t(),
+          total_fees: Dwolla.Amount.t()
+        }
+
+  @type token :: String.t()
+  @type id :: String.t()
+  @type params :: %{required(atom) => any}
+  @type error :: HTTPoison.Error.t() | Dwolla.Errors.t() | tuple
+  @type location :: %{id: String.t()}
+
+  @endpoint "mass-payments"
+
+  defmodule Item do
+    @moduledoc """
+    Dwolla Mass Payment Item data structure
+    """
+    defstruct id: nil,
+              dest_resource: nil,
+              dest_resource_id: nil,
+              amount: nil,
+              metadata: nil,
+              status: nil,
+              errors: nil,
+              transfer_id: nil
+
+    @type t :: %__MODULE__{
+            id: String.t(),
+            dest_resource: String.t(),
+            dest_resource_id: String.t(),
+            amount: Dwolla.Amount.t(),
+            metadata: Map.t(),
+            status: String.t(),
+            # "failed" | "pending" | "success"
+            errors: Dwolla.Errors.t(),
+            transfer_id: String.t()
+          }
+  end
+
+  @doc """
+  Initiates a mass payment.
+
+  The parameters are verbose because of the many options available to the user
+  for setting the source and destination of the funds in the `href` field.
+
+  Parameters
+  ```
+  %{
+      _links: %{
+        source: %{
+          href: "https://api-uat.dwolla.com/funding-sources/..."
+        }
+      },
+      items: [
+        %{
+          _links: %{
+            destination: %{
+              href: "https://api-uat.dwolla.com/funding-sources/..."
+            }
+          },
+          amount: %{
+            value: 1.00,
+            currency: "USD"
+          }
+        }
+      ],
+      correlation_id: "3e17e4ad-4136-2fd3-a45d-adaa015d494c"
+    }
+  ```
+  """
+  @spec initiate(token, params, any) :: {:ok, location} | {:error, error}
+  def initiate(token, params, idempotency_key) do
+    headers = Utils.idempotency_header(idempotency_key)
+
+    Dwolla.make_request_with_token(:post, @endpoint, token, params, headers)
+    |> Utils.handle_resp(:mass_payment)
+  end
+
+  @doc """
+  Gets a mass payment by id.
+  """
+  @spec get(token, id) :: {:ok, Dwolla.MassPayment.t()} | {:error, error}
+  def get(token, id) do
+    endpoint = @endpoint <> "/#{id}"
+
+    Dwolla.make_request_with_token(:get, endpoint, token)
+    |> Utils.handle_resp(:mass_payment)
+  end
+
+  @doc """
+  Gets items in a mass payment by id. Results paginated.
+
+  Parameters
+  ```
+  %{limit: 25, offset: 0, status: "pending"}
+  ```
+  """
+  @spec get_items(token, id, params) :: {:ok, [Dwolla.MassPayment.Item.t()]} | {:error, error}
+  def get_items(token, id, params \\ %{}) do
+    endpoint =
+      case Map.keys(params) do
+        [] -> @endpoint <> "/#{id}/items"
+        _ -> @endpoint <> "/#{id}/items?" <> Utils.encode_params(params)
+      end
+
+    Dwolla.make_request_with_token(:get, endpoint, token)
+    |> Utils.handle_resp(:mass_payment_items)
+  end
+end

--- a/lib/dwolla/transfer.ex
+++ b/lib/dwolla/transfer.ex
@@ -22,7 +22,7 @@ defmodule Dwolla.Transfer do
           created: String.t(),
           # "pending" | "processed" | "cancelled" | "failed" | "reclaimed"
           status: String.t(),
-          amount: Dwolla.Transfer.Amount.t(),
+          amount: Dwolla.Amount.t(),
           metadata: Dwolla.Transfer.Metadata.t(),
           source_resource: String.t(),
           source_resource_id: String.t(),
@@ -39,15 +39,6 @@ defmodule Dwolla.Transfer do
   @type location :: %{id: String.t()}
 
   @endpoint "transfers"
-
-  defmodule Amount do
-    @moduledoc """
-    Dwolla Transfer Amount data structure.
-    """
-
-    defstruct value: nil, currency: nil
-    @type t :: %__MODULE__{value: String.t(), currency: String.t()}
-  end
 
   defmodule Metadata do
     @moduledoc """

--- a/test/lib/dwolla/mass_payment_test.exs
+++ b/test/lib/dwolla/mass_payment_test.exs
@@ -1,0 +1,112 @@
+defmodule Dwolla.MassPaymentTest do
+  use ExUnit.Case
+
+  import Dwolla.Factory
+
+  alias Dwolla.MassPayment
+  alias Plug.Conn
+
+  setup do
+    bypass = Bypass.open()
+    Application.put_env(:dwolla, :root_uri, "http://localhost:#{bypass.port}/")
+    {:ok, bypass: bypass}
+  end
+
+  describe "MassPayment" do
+    test "initiate/2 requests POST and returns a new id", %{bypass: bypass} do
+      Bypass.expect(bypass, fn conn ->
+        assert "POST" == conn.method
+        {k, v} = http_response_header(:mass_payment)
+
+        conn
+        |> Conn.put_resp_header(k, v)
+        |> Conn.resp(201, "")
+      end)
+
+      params = %{
+        _links: %{
+          source: %{
+            href: "https://api-uat.dwolla.com/funding-sources/sender-id"
+          }
+        },
+        items: [
+          %{
+            _links: %{
+              destination: %{
+                href: "https://api-uat.dwolla.com/funding-sources/recip-id"
+              }
+            },
+            amount: %{
+              value: 1.00,
+              currency: "USD"
+            },
+            metadata: %{
+              batch1: "batch1"
+            }
+          }
+        ],
+        metadata: %{
+          batch1: "batch1"
+        },
+        correlation_id: "3e17e4ad-4136-2fd3-a45d-adaa015d494c"
+      }
+
+      assert {:ok, resp} = MassPayment.initiate("token", params, "12345")
+      assert resp.id == "4f4edcdc-49c2-41ca-a71c-adab014e98b9"
+    end
+
+    test "get/2 requests GET and returns Dwolla.MassPayment", %{bypass: bypass} do
+      body = http_response_body(:mass_payment, :get)
+
+      Bypass.expect(bypass, fn conn ->
+        assert "GET" == conn.method
+        Conn.resp(conn, 200, body)
+      end)
+
+      assert {:ok, resp} = MassPayment.get("token", "id")
+      assert resp.__struct__ == Dwolla.MassPayment
+      assert resp.correlation_id == "3e17e4ad-4136-2fd3-a45d-adaa015d494c"
+      assert resp.created == "2021-09-22T20:18:17.000Z"
+      assert resp.funding_transfer_id == "f24b8135-e21b-ec11-8138-fd945f81a1fa"
+      assert resp.id == "4f4edcdc-49c2-41ca-a71c-adab014e98b9"
+      assert resp.metadata == %{"batch1" => "batch1"}
+      assert resp.source_funding_source_id == "e7bd5db2-f290-47c8-a3e1-c976af9146d7"
+      assert resp.status == "complete"
+      assert resp.total == %{"currency" => "USD", "value" => "1.00"}
+      assert resp.total_fees == %{"currency" => "USD", "value" => "0.00"}
+    end
+
+    test "get_items/2 requests GET and returns [Dwolla.MassPayment.Items]", %{bypass: bypass} do
+      body = http_response_body(:mass_payment_items, :get)
+
+      Bypass.expect(bypass, fn conn ->
+        assert "GET" == conn.method
+        Conn.resp(conn, 200, body)
+      end)
+
+      assert {:ok, resp} = MassPayment.get_items("token", "id")
+      item = hd(resp)
+      assert item.__struct__ == Dwolla.MassPayment.Item
+      assert item.amount == %{"currency" => "USD", "value" => "1.00"}
+      assert item.dest_resource == "accounts"
+      assert item.dest_resource_id == "b010e278-3831-4d09-91b0-067e6c56da72"
+
+      assert item.errors == %Dwolla.Errors{
+               code: nil,
+               errors: [
+                 %Dwolla.Errors.Error{
+                   code: "Invalid",
+                   message: "Receiver cannot be the owner of the source funding source.",
+                   path: "/items/destination/href"
+                 }
+               ],
+               message: nil
+             }
+
+      assert item.id == "61bfea12-79ba-4aeb-9a9b-4d199b48de2b"
+      assert item.metadata == %{"batch1" => "batch1"}
+      assert item.status == "failed"
+      assert item.transfer_id == nil
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -65,6 +65,14 @@ defmodule Dwolla.Factory do
     "{\"_links\": {\"self\": {\"href\": \"https://api-sandbox.dwolla.com/transfers/E6D9A950-AC9E-E511-80DC-0AA34A9B2388/failure\",\"type\":\"application/vnd.dwolla.v1.hal+json\",\"resource-type\":\"failure\"}},\"code\":\"R1\",\"description\":\"Insufficient Funds\"}"
   end
 
+  def http_response_body(:mass_payment, :get) do
+    "{\"_links\": {\"funding-transfer\": {\"href\": \"https://api-sandbox.dwolla.com/transfers/f24b8135-e21b-ec11-8138-fd945f81a1fa\", \"resource-type\": \"transfer\", \"type\": \"application/vnd.dwolla.v1.hal+json\"}, \"items\": {\"href\": \"https://api-sandbox.dwolla.com/mass-payments/4f4edcdc-49c2-41ca-a71c-adab014e98b9/items\", \"resource-type\": \"mass-payment-item\", \"type\": \"application/vnd.dwolla.v1.hal+json\"}, \"self\": {\"href\": \"https://api-sandbox.dwolla.com/mass-payments/4f4edcdc-49c2-41ca-a71c-adab014e98b9\", \"resource-type\": \"mass-payment\", \"type\": \"application/vnd.dwolla.v1.hal+json\"}, \"source\": {\"href\": \"https://api-sandbox.dwolla.com/funding-sources/e7bd5db2-f290-47c8-a3e1-c976af9146d7\", \"resource-type\": \"funding-source\", \"type\": \"application/vnd.dwolla.v1.hal+json\"}}, \"correlationId\": \"3e17e4ad-4136-2fd3-a45d-adaa015d494c\", \"created\": \"2021-09-22T20:18:17.000Z\", \"id\": \"4f4edcdc-49c2-41ca-a71c-adab014e98b9\", \"metadata\": {\"batch1\": \"batch1\"}, \"status\": \"complete\", \"total\": {\"currency\": \"USD\", \"value\": \"1.00\"}, \"totalFees\": {\"currency\": \"USD\", \"value\": \"0.00\"}}"
+  end
+
+  def http_response_body(:mass_payment_items, :get) do
+    "{\"_embedded\": {\"items\": [{\"_embedded\": {\"errors\": [{\"_links\": {}, \"code\": \"Invalid\", \"message\": \"Receiver cannot be the owner of the source funding source.\", \"path\": \"/items/destination/href\"}]}, \"_links\": {\"destination\": {\"href\": \"https://api-sandbox.dwolla.com/accounts/b010e278-3831-4d09-91b0-067e6c56da72\", \"resource-type\": \"account\", \"type\": \"application/vnd.dwolla.v1.hal+json\"}, \"mass-payment\": {\"href\": \"https://api-sandbox.dwolla.com/mass-payments/4f4edcdc-49c2-41ca-a71c-adab014e98b9\", \"resource-type\": \"mass-payment\", \"type\": \"application/vnd.dwolla.v1.hal+json\"}, \"self\": {\"href\": \"https://api-sandbox.dwolla.com/mass-payment-items/61bfea12-79ba-4aeb-9a9b-4d199b48de2b\", \"resource-type\": \"mass-payment-item\", \"type\": \"application/vnd.dwolla.v1.hal+json\"}}, \"amount\": {\"currency\": \"USD\", \"value\": \"1.00\"}, \"created\": \"2021-09-22T20:18:17.000Z\", \"id\": \"61bfea12-79ba-4aeb-9a9b-4d199b48de2b\", \"metadata\": {\"batch1\": \"batch1\"}, \"status\": \"failed\"}]}, \"_links\": {\"first\": {\"href\": \"https://api-sandbox.dwolla.com/mass-payments/4f4edcdc-49c2-41ca-a71c-adab014e98b9/items?&limit=25&offset=0\", \"resource-type\": \"mass-payment-item\", \"type\": \"application/vnd.dwolla.v1.hal+json\"}, \"last\": {\"href\": \"https://api-sandbox.dwolla.com/mass-payments/4f4edcdc-49c2-41ca-a71c-adab014e98b9/items?&limit=25&offset=0\", \"resource-type\": \"mass-payment-item\",\"type\": \"application/vnd.dwolla.v1.hal+json\"}, \"self\": {\"href\": \"https://api-sandbox.dwolla.com/mass-payments/4f4edcdc-49c2-41ca-a71c-adab014e98b9/items\", \"resource-type\": \"mass-payment-item\", \"type\": \"application/vnd.dwolla.v1.hal+json\"}}, \"total\": 1}"
+  end
+
   def http_response_body(:event, :list) do
     "{\"_links\":{\"self\":{\"href\":\"https://api-sandbox.dwolla.com/events\"},\"first\":{\"href\":\"https://api-sandbox.dwolla.com/events?limit=25&offset=0\"},\"last\":{\"href\":\"https://api-sandbox.dwolla.com/events?limit=25&offset=150\"},\"next\":{\"href\":\"https://api-sandbox.dwolla.com/events?limit=25&offset=25\"}},\"_embedded\":{\"events\":[{\"_links\":{\"self\":{\"href\":\"https://api-sandbox.dwolla.com/events/78e57644-56e4-4da2-b743-059479f2e80f\",\"type\":\"application/vnd.dwolla.v1.hal+json\",\"resource-type\":\"event\"},\"resource\":{\"href\":\"https://api-sandbox.dwolla.com/transfers/47CFDDB4-1E74-E511-80DB-0AA34A9B2388\"},\"account\":{\"href\":\"https://api-sandbox.dwolla.com/accounts/ca32853c-48fa-40be-ae75-77b37504581b\"}},\"id\":\"78e57644-56e4-4da2-b743-059479f2e80f\",\"created\":\"2015-10-16T15:58:18.000Z\",\"topic\":\"bank_transfer_created\",\"resourceId\":\"47CFDDB4-1E74-E511-80DB-0AA34A9B2388\"},{\"_links\":{\"self\":{\"href\":\"https://api-sandbox.dwolla.com/events/f8e70f48-b7ff-47d0-9d3d-62a099363a76\",\"type\":\"application/vnd.dwolla.v1.hal+json\",\"resource-type\":\"event\"},\"resource\":{\"href\":\"https://api-sandbox.dwolla.com/transfers/48CFDDB4-1E74-E511-80DB-0AA34A9B2388\"},\"account\":{\"href\":\"https://api-sandbox.dwolla.com/accounts/ca32853c-48fa-40be-ae75-77b37504581b\"}},\"id\":\"f8e70f48-b7ff-47d0-9d3d-62a099363a76\",\"created\":\"2015-10-16T15:58:15.000Z\",\"topic\":\"transfer_created\",\"resourceId\":\"48CFDDB4-1E74-E511-80DB-0AA34A9B2388\"}]},\"total\": 2}"
   end
@@ -112,6 +120,11 @@ defmodule Dwolla.Factory do
 
   def http_response_header(:transfer) do
     {"Location", "https://api-sandbox.dwolla.com/transfers/494b6269-d909-e711-80ee-0aa34a9b2388"}
+  end
+
+  def http_response_header(:mass_payment) do
+    {"Location",
+     "https://api-sandbox.dwolla.com/mass-payments/4f4edcdc-49c2-41ca-a71c-adab014e98b9"}
   end
 
   def http_response_header(:webhook_subscription) do


### PR DESCRIPTION
What is supported:

- Creating a mass payment
- Getting a mass payment
- Getting the items associated with a mass payment

What is NOT supported:

- Creating a deferred mass payment
- Editing a (deferred) mass payment
- Auto-generating an idempotency key for a mass payment